### PR TITLE
Bump base module and update deprecated code

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -1,5 +1,5 @@
 [dependencies]
-base = "https://github.com/dfinity/motoko-base#494824a2787aee24ab4a5888aa519deb05ecfd60"
+base = "https://github.com/dfinity/motoko-base#moc-0.7.4"
 xtendedNumbers = "https://github.com/edjcase/motoko_numbers#v1.0.0"
 
 [package]


### PR DESCRIPTION
Hey @Gekctek, I'm using this library as a dependency and wanted to add this PR to remove the warnings returns in recent versions of the base module.
I bumped the base module to the latest version (`0.7.4`) and switched the deprecated `.toArray()` instance method to the `Buffer.toArray()` static method.